### PR TITLE
Use of NQP outside of core is now deprecated

### DIFF
--- a/lib/Slang/SQL.pm6
+++ b/lib/Slang/SQL.pm6
@@ -1,3 +1,4 @@
+use nqp;
 use QAST:from<NQP>;
 
 sub Slang::SQL::sql(Str $statement, @args?, $cb?) is export {


### PR DESCRIPTION
Need the use nqp;  there is another bug around the Mu $/ is rw I dont think $/ is a rw value? So due to recent changes it dies on binding at the method call. Here's my panda output FYI:

$ panda install Slang::SQL
==> Fetching Slang::SQL
==> Building Slang::SQL
# ==> Testing Slang::SQL

The use of nqp::operations has been deprecated for non-CORE code.  Please
change your code to not use these non-portable functions.  If you really want
to keep using nqp::operations in your Perl6 code, you must add a:

  use nqp;

to the outer scope of any code that uses nqp::operations.

Compilation unit '/Users/con-mo8/test/.panda-work/1443699558_1/lib/Slang/SQL.pm6' contained the following violations:
 Line 41:
  nqp::findmethod nqp::atkey
 Line 73:
  nqp::bindkey
 Line 74:
#   nqp::bindkey

===SORRY!===
X::Parameter::RW exception produced no message
t/01_basic.t ..
No subtests run
## Test Summary Report

t/01_basic.t (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  2 wallclock secs ( 0.02 usr  0.01 sys +  2.04 cusr  0.08 csys =  2.15 CPU)
Result: FAIL
test stage failed for Slang::SQL: Tests failed
  in method throw at /Users/con-mo8/.rakudobrew/moar-nom/install/share/perl6/runtime/CORE.setting.moarvm:1
  in method install at /Users/con-mo8/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda.pm:142
  in method resolve at /Users/con-mo8/.rakudobrew/moar-nom/install/share/perl6/site/lib/Panda.pm:219
  in sub MAIN at /Users/con-mo8/.rakudobrew/bin/../moar-nom/install/share/perl6/site/bin/panda:18
  in block <unit> at /Users/con-mo8/.rakudobrew/bin/../moar-nom/install/share/perl6/site/bin/panda:95
## Failure Summary

Slang::SQL(
    *test stage failed for Slang::SQL: Tests failed)
