### PR TITLE
Just remove the is rw?

### DIFF
--- a/lib/Slang/SQL.pm6
+++ b/lib/Slang/SQL.pm6
@@ -42,7 +42,7 @@ sub EXPORT(|) {
       nqp::atkey(nqp::findmethod(h, 'hash')(h), k)
     }
 
-    method statement_control:sym<sql>(Mu $/ is rw) {
+    method statement_control:sym<sql>(Mu $/) {
       my $sql   := lk($/, 'sql');
       my $args  := lk($/, 'arglist');
       my $cb    := lk($/, 'pblock');


### PR DESCRIPTION
Locally from what I can tell the is rw was never necessary? Just removing it gets rid of the error and basic select queries at least appear to work.
